### PR TITLE
Animate AI rotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ python3 self_playing_tetris_pygame.py
 ```
 
 The AI automatically chooses moves and displays them in a window. Each
-tetromino falls row by row with a short pause after it lands so you can watch
-the strategy unfold. The UI now shows the next tetromino, a held piece and
+tetromino rotates to the selected orientation one step at a time and then
+falls row by row with a short pause after it lands so you can watch the
+strategy unfold. The UI now shows the next tetromino, a held piece and
 the current score on a side panel.

--- a/self_playing_tetris_pygame.py
+++ b/self_playing_tetris_pygame.py
@@ -11,6 +11,8 @@ SIDE_PANEL_WIDTH = 6 * CELL_SIZE
 MOVE_DELAY = 200
 # Delay between each row of the falling piece (milliseconds)
 FALL_STEP_DELAY = 50
+# Delay between each frame of a rotation (milliseconds)
+ROTATE_STEP_DELAY = 50
 
 # Tetromino definitions with their rotation states
 TETROMINOES = {
@@ -230,6 +232,31 @@ def main():
                 action = 'use_current'
                 shape, x = shape_cur, x_cur
                 piece = current_piece
+
+        # Animate rotation to the chosen orientation
+        target_rot = TETROMINOES[piece].index(shape)
+        cur_rot = 0
+        while running and cur_rot != target_rot:
+            cur_rot = (cur_rot + 1) % len(TETROMINOES[piece])
+            temp_shape = TETROMINOES[piece][cur_rot]
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                    break
+            if not running:
+                break
+            draw_board(screen, board, font, score, next_piece, hold_piece)
+            for px, py in temp_shape:
+                rect = pygame.Rect((x + px) * CELL_SIZE,
+                                   py * CELL_SIZE,
+                                   CELL_SIZE, CELL_SIZE)
+                if py >= 0 and 0 <= x + px < BOARD_WIDTH:
+                    pygame.draw.rect(screen, COLORS[piece], rect)
+            pygame.display.flip()
+            pygame.time.wait(ROTATE_STEP_DELAY)
+
+        if not running:
+            break
 
         y = drop_y(board, shape, x)
         if y < 0:


### PR DESCRIPTION
## Summary
- add small delay between rotation frames so the AI visibly rotates pieces
- animate rotation to chosen orientation before each drop
- document rotation in the README

## Testing
- `python3 -m py_compile self_playing_tetris_pygame.py`
- `DISPLAY= python3 self_playing_tetris_pygame.py` *(fails: ModuleNotFoundError: No module named 'pygame')*