### PR TITLE
Improve RL env display and checkpoint management

### DIFF
--- a/rl_agent.py
+++ b/rl_agent.py
@@ -76,9 +76,10 @@ class Agent:
         with torch.no_grad():
             next_q = self.target_net(next_states).max(1)[0]
             target = rewards + self.gamma * next_q * (1 - dones)
-        loss = nn.functional.mse_loss(q_values, target)
+        loss = nn.functional.smooth_l1_loss(q_values, target)
         self.optimizer.zero_grad()
         loss.backward()
+        nn.utils.clip_grad_norm_(self.policy_net.parameters(), 1.0)
         self.optimizer.step()
         if self.steps_done % 100 == 0:
             self.target_net.load_state_dict(self.policy_net.state_dict())

--- a/rl_env.py
+++ b/rl_env.py
@@ -1,8 +1,8 @@
 import random
 import pygame
 from board import (
-    BOARD_WIDTH, BOARD_HEIGHT, CELL_SIZE, TETROMINOES,
-    COLORS, BACKGROUND_COLOR, GRID_COLOR,
+    BOARD_WIDTH, BOARD_HEIGHT, CELL_SIZE, SIDE_PANEL_WIDTH,
+    TETROMINOES, COLORS, BACKGROUND_COLOR, GRID_COLOR,
     empty_board, check_collision, drop_y, place_piece, clear_lines
 )
 
@@ -116,20 +116,50 @@ class TetrisEnv:
         return obs, reward, done, {}
 
     def render(self, surface, offset_x=0, offset_y=0):
-        # draw board
+        """Render the environment to the given surface."""
+        # draw board background
+        board_width_px = BOARD_WIDTH * CELL_SIZE
+        board_height_px = BOARD_HEIGHT * CELL_SIZE
+        pygame.draw.rect(surface, BACKGROUND_COLOR,
+                         pygame.Rect(offset_x, offset_y,
+                                    board_width_px + SIDE_PANEL_WIDTH,
+                                    board_height_px))
+
+        # draw board cells
         for y, row in enumerate(self.board):
             for x, cell in enumerate(row):
-                rect = pygame.Rect(offset_x + x*CELL_SIZE, offset_y + y*CELL_SIZE, CELL_SIZE, CELL_SIZE)
+                rect = pygame.Rect(offset_x + x*CELL_SIZE,
+                                   offset_y + y*CELL_SIZE,
+                                   CELL_SIZE, CELL_SIZE)
                 pygame.draw.rect(surface, GRID_COLOR, rect, 1)
                 if cell is not None:
                     pygame.draw.rect(surface, COLORS[cell], rect)
-        # draw current piece
+
+        # draw current falling piece
         shape = TETROMINOES[self.current_piece][self.rotation]
         for px, py in shape:
             py = self.piece_y + py
             px = self.piece_x + px
-            if py >=0:
-                rect = pygame.Rect(offset_x + px*CELL_SIZE, offset_y + py*CELL_SIZE, CELL_SIZE, CELL_SIZE)
+            if py >= 0:
+                rect = pygame.Rect(offset_x + px*CELL_SIZE,
+                                   offset_y + py*CELL_SIZE,
+                                   CELL_SIZE, CELL_SIZE)
                 pygame.draw.rect(surface, COLORS[self.current_piece], rect)
+
+        panel_x = offset_x + board_width_px + 10
+        # next piece
+        for px, py in TETROMINOES[self.next_piece][0]:
+            rect = pygame.Rect(panel_x + px*CELL_SIZE,
+                               offset_y + 20 + py*CELL_SIZE,
+                               CELL_SIZE, CELL_SIZE)
+            pygame.draw.rect(surface, COLORS[self.next_piece], rect)
+
+        # hold piece
+        if self.hold_piece is not None:
+            for px, py in TETROMINOES[self.hold_piece][0]:
+                rect = pygame.Rect(panel_x + px*CELL_SIZE,
+                                   offset_y + 90 + py*CELL_SIZE,
+                                   CELL_SIZE, CELL_SIZE)
+                pygame.draw.rect(surface, COLORS[self.hold_piece], rect)
 
 


### PR DESCRIPTION
## Summary
- render hold and next pieces in each RL environment
- show environments in a 4x2 grid with separators
- keep only five latest checkpoints when training
- clip gradients and use SmoothL1 loss to stabilise training

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 train_rl.py --episodes 1 --num_envs 8` *(fails: ModuleNotFoundError: No module named 'pygame')*